### PR TITLE
setup.py file for standard python installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include scr/openvibspec models/*
+
+global-exclude __pycache__
+
+README.md

--- a/scr/openvibspec/ml_ftir.py
+++ b/scr/openvibspec/ml_ftir.py
@@ -10,6 +10,7 @@ import h5py
 import numpy as np 
 #import scipy.io as sio 
 import sklearn
+import os
 import pickle
 import matplotlib.pyplot as plt
 # python 2.7 from sklearn.cross_validation import train_test_split 
@@ -25,6 +26,8 @@ plt.style.use('ggplot')
 #from keras.callbacks import ModelCheckpoint
 ###########################################
 
+import openvibspec.models
+MODELPATH = os.path.dirname(openvibspec.models.__file__)
 
 
 
@@ -183,7 +186,7 @@ class DeepLearn:
 
 		if classify == True:
 			
-			json_file = open('openvibspec/models/model_weights_classification.json', 'r')
+			json_file = open(os.path.join(MODELPATH, 'model_weights_classification.json'), 'r')
 		
 			loaded_model_json = json_file.read()
 			loaded_model = model_from_json(loaded_model_json)
@@ -191,7 +194,7 @@ class DeepLearn:
 			if show == True:
 				print(loaded_model.summary())
 			
-			loaded_model.load_weights("openvibspec/models/model_weights_classification.best.hdf5")
+			loaded_model.load_weights(os.path.join(MODELPATH, "model_weights_classification.best.hdf5"))
 			
 			print("Loaded model from disk")
 			
@@ -207,7 +210,7 @@ class DeepLearn:
 			#	
 			####################################################################################################x
 
-			json_file = open('openvibspec/models/model_weights_regression.json', 'r')
+			json_file = open(os.path.join(MODELPATH, 'model_weights_regression.json'), 'r')
 		
 			loaded_model_json = json_file.read()
 			loaded_model = model_from_json(loaded_model_json)
@@ -215,7 +218,7 @@ class DeepLearn:
 			if show == True:
 				print(loaded_model.summary())
 			
-			loaded_model.load_weights("openvibspec/models/model_weights_regression.best.hdf5")
+			loaded_model.load_weights(os.path.join(MODELPATH, "model_weights_regression.best.hdf5"))
 			
 			print("Loaded model from disk")
 			

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+
+if __name__ == '__main__':
+
+    setup(
+        name="OpenVibSpec",
+        version="0.0.1",
+        package_dir={'': 'scr'},
+        packages=['openvibspec'],
+        include_package_data=True,
+        install_requires=[
+            'matplotlib',
+            'keras',
+            'numpy',
+            'scipy',
+            'scikit-learn',
+            'h5py',
+            'tensorflow',
+        ],
+    )


### PR DESCRIPTION
Library is now installable with `pip install .`.

Also takes care of the requirements. Versions of the requirements were left undefined.