### PR TITLE
Implemented spectra rendering via LaTeX / tikz

### DIFF
--- a/scr/openvibspec/nn_utils.py
+++ b/scr/openvibspec/nn_utils.py
@@ -350,6 +350,32 @@ class PlotTrainingLiveCallback(Callback):
 
 
 # ###############################
+# STATIC FIELDS
+# ###############################
+
+pgf_plot_colors = [
+    'red',
+    'green',
+    'blue',
+    'cyan',
+    'magenta',
+    'yellow',
+    'black',
+    'gray',
+    'darkgray',
+    'lightgray',
+    'brown',
+    'lime',
+    'olive',
+    'orange',
+    'pink',
+    'purple',
+    'teal',
+    'violet',
+    'white']
+
+
+# ###############################
 # OTHER UTIL FUNCTIONS
 # ###############################
 
@@ -462,8 +488,8 @@ def create_tikz_axis(title: str, label_y: str, label_x: str = 'Epoch', max_x: fl
 
 def get_plt_as_tex(data_list_y: [[float]], plot_colors: [str], title: str, label_y: str, data_list_x: [[float]] = None,
                    plot_titles: [str] = None, label_x: str = 'Epoch', max_x: float = 1.0, min_x: float = 0.0,
-                   max_y: float = 1.0,
-                   min_y: float = 0.0, max_entries: int = 4000, tick_count: int = 10, legend_pos: str = 'north west'):
+                   max_y: float = 1.0, min_y: float = 0.0, max_entries: int = 4000, tick_count: int = 10,
+                   legend_pos: str = 'north west') -> str:
     """
     Formats a list of given plots in a single tikz axis to be compiled in LaTeX.
     

--- a/scr/openvibspec/visualize.py
+++ b/scr/openvibspec/visualize.py
@@ -8,6 +8,10 @@ from __future__ import absolute_import
 ###########################################
 import matplotlib.pyplot as plt
 import numpy as np
+
+from scr.openvibspec.nn_utils import get_plt_as_tex
+from scr.openvibspec.nn_utils import pgf_plot_colors
+
 plt.style.use('ggplot')
 ###########################################
 
@@ -368,4 +372,158 @@ FUNCTION TO GET SEGMENTATION PLOT WITH THE COLOR SCHEME OF MATLAB USED IN THE FO
 #					#plt.show()
 #					plt.clf()
 #					return
-#				
+#
+
+
+def spectra_to_tex(spectra: np.ndarray, wave_numbers, plot_title: str, label_y: str, label_x: str = '$cm^{-1}$',
+				   included_wave_number_indices: [int] = None, round_plot_bounds: bool = False,
+				   max_entries_per_wave_number: int = 200, out_file_path: str = 'my_plot.tex',
+				   graph_colors: [str] = None, legend_entries: [str] = None, legend_pos: str = 'north west',
+				   used_spectra_mask: np.ndarray = None) -> str:
+	"""
+	Sets up a tikz pgf-plot for a 2D spectral image.
+	If a path is specified, the spectra can be saved as a .tex
+	formatted file.
+	The formatted text will be returned as a string.
+
+	You can mask out a (int) list of wave-numbers that should be ignored in the output.
+	Also a 2D binary array can be supplied to mask out specific areas that will be ignored in the spectral image.
+
+	Note that the required array dimensions are:
+	 - "spectra" shape: (x, y, z)
+	 - "wave_numbers" shape: (z, 1)
+	 - "included_wave_number_indices" shape: (z, 1)
+	 - "used_spectra_mask" shape: (x, y)
+
+	x, y, and z should be greater than 0.
+
+	Created by Nils Förster.
+
+	:param spectra: The spectra to be rendered (as a 2D array for every wave-number).
+	:param wave_numbers: The corresponding wave-numbers to be rendered (x-axis).
+	:param plot_title: The text above the plot.
+	:param label_y: The text next to the y-axis.
+	:param label_x: The text below the x-axis. Default: cm^(-1)
+	:param included_wave_number_indices: A 1D array containing all wave-number indices to be rendered. Optional. If set to None, all well-numbers will be rendered. Default: False
+	:param round_plot_bounds: Set to True, if you want to extend the axis bounds a bit and round to 3 digits. Default: False.
+	:param max_entries_per_wave_number: How many entries per wave-number should be rendered? Set to lower, if you run into RAM issues during rendering. Best set to default: 200.
+	:param out_file_path: A filename where the tikz text should be saved to. File is overwritten. If None, output is not saved. Default: None.
+	:param graph_colors: A 1D string array to overwrite graph colors. If None, default colors will be used. Default: None.
+	:param legend_entries: A 1D string array to specify legend labels. IF None, no legend will be rendered. Default: None.
+	:param legend_pos: The position of the legend. Default: Auto.
+	:param used_spectra_mask: A 2D boolean array to mask out spectra from rendering. If None, all spectra will be rendered. Default: None.
+
+	:type spectra: np.ndarray
+	:type wave_numbers: np.ndarray
+	:type plot_title: str
+	:type label_y: str
+	:type label_x: str
+	:type included_wave_number_indices: [int]
+	:type round_plot_bounds: bool
+	:type max_entries_per_wave_number: int
+	:type out_file_path: str
+	:type graph_colors: [str]
+	:type legend_entries: [str]
+	:type legend_pos: str
+	:type used_spectra_mask: np.ndarray
+
+	:returns: The formatted string to be rendered as a LaTeX tikz-pgf plot.
+	:rtype: str
+	"""
+
+	# Setting up holders to use later for data
+	points_x = {}
+	points_y = {}
+	all_colors = pgf_plot_colors[:-1]
+
+	# Converting the mask to bool. If none have been given via args, a new one is created (consisting of only 1s).
+	if used_spectra_mask is None:
+		used_spectra_mask = np.ones((spectra.shape[0], spectra.shape[1]))
+	used_spectra_mask = used_spectra_mask.astype(np.bool)
+
+	# Asserting data and masks
+	assert used_spectra_mask.shape[0] == spectra.shape[0]
+	assert used_spectra_mask.shape[1] == spectra.shape[1]
+
+	# Collecting the spectra input dim and reshaping mask accordingly
+	dim = spectra.shape[0] * spectra.shape[1]
+	used_spectra_mask = used_spectra_mask.reshape(dim)
+
+	# Filling the previously setup dicts with empty list...
+	for d in range(dim):
+		# ... but only if they are in bounds of the mask
+		if used_spectra_mask[d]:
+			points_x[d] = []
+			points_y[d] = []
+
+	# If graph colors are not given via arguments, they are picked from the list of all possible colors
+	if graph_colors is None:
+		graph_colors = []
+		for d in range(dim):
+			graph_colors.append(all_colors[d % len(all_colors)])
+
+	# If the included wave numbers are not given via arguments, they are created new to include all
+	if included_wave_number_indices is None:
+		included_wave_number_indices = list(range(len(wave_numbers)))
+	assert len(included_wave_number_indices) == len(wave_numbers)
+
+	# If the entries for the legend are set, they are asserted to have the right format
+	if legend_entries is not None:
+		assert legend_pos is not None
+		assert len(legend_entries) == len(wave_numbers)
+
+	# iterating over all indices within the wave-number array
+	for i in range(len(wave_numbers)):
+		# Check if they are not masked out
+		if i not in included_wave_number_indices:
+			continue
+
+		# Getting the current wave number
+		current_wave_number = wave_numbers[i]
+
+		# Getting the current spectrum 2D-image slice and reshaping it to 1D
+		current_slice = spectra[:, :, i]
+		current_slice = current_slice.reshape(dim)
+
+		# Iterating over all spectra from the slice
+		for d in range(dim):
+			# Check if they are not masked out
+			if used_spectra_mask[d]:
+				# Adding the current wave-number and spectrum to the x / y arrays to be plotted
+				points_y[d].append(current_slice[d])
+				points_x[d].extend(current_wave_number)
+
+	# Converting the x / y dicts to lists
+	#  (used dicts to allow sparse entries)
+	points_x = list(points_x.values())
+	points_y = list(points_y.values())
+
+	# Converting to NP arrays to easily find min / max entries
+	points_x_np = np.array(points_x)
+	points_y_np = np.array(points_y)
+	min_x = float(points_x_np.min())
+	max_x = float(points_x_np.max())
+	min_y = float(points_y_np.min())
+	max_y = float(points_y_np.max())
+	# Rounding to the 3rd decimal point if desired
+	if round_plot_bounds:
+		min_x = round(min_x * 1.05, 3)
+		max_x = round(max_x * 1.05, 3)
+		min_y = round(min_y * 1.05, 3)
+		max_y = round(max_y * 1.05, 3)
+
+	# Formatting to LaTeX tikz string
+	tex = get_plt_as_tex(data_list_y=points_y, data_list_x=points_x, plot_colors=graph_colors, label_x=label_x,
+						 label_y=label_y, min_x=min_x, max_x=max_x, title=plot_title, plot_titles=legend_entries,
+						 max_entries=max_entries_per_wave_number, min_y=min_y, max_y=max_y, legend_pos=legend_pos)
+
+	# If the path is not None, the tex-str is written to the corresponding filename
+	if out_file_path is not None:
+		f = open(out_file_path, 'w')
+		f.write(tex)
+		f.close()
+
+	# Returning the text
+	return tex
+
+


### PR DESCRIPTION
With this extension to the visualize.py file, you can transform spectra into tikz / pgf plots to be rendered with a LaTeX compiler.